### PR TITLE
Feature/pop last

### DIFF
--- a/tracker/main.py
+++ b/tracker/main.py
@@ -28,6 +28,18 @@ def get_last_track():
             pass
         return line
 
+def remove_last_track():
+    # https://stackoverflow.com/a/10289740
+    with open(os.path.join(config_data["output_directory"], "tracks.csv"), "r") as f:
+        f.seek(0, os.SEEK_END)
+        pos = f.tell() - 1
+        while pos > 0 and f.read(1) != "\n":
+            pos -= 1
+            f.seek(pos, os.SEEK_SET)
+        if pos > 0:
+            f.seek(pos, os.SEEK_SET)
+            f.truncate()
+
 @app.command()
 def track(message: str = None, m: str = None, ticket: str = None, t: str = None, past: bool = False, p: bool = False):
     message = message or m
@@ -64,6 +76,9 @@ def show():
 def clear():
     os.remove(os.path.join(config_data["output_directory"], "tracks.csv")) 
 
+@app.command()
+def pop():
+    remove_last_track()
 
 def run() -> None:
     app()

--- a/tracker/main.py
+++ b/tracker/main.py
@@ -15,12 +15,10 @@ def get_input(text):
 def add_track(date, start, end, ticket, message):
     with open(os.path.join(config_data["output_directory"], "tracks.csv"), "a") as f:
         f.write(";".join([date, start, end, ticket, message]) + "\n")
-    f.close()
 
 def safe_config(config_data):
     with open(importlib.resources.files("tracker").joinpath("config.yml"), "w") as f:
         yaml.safe_dump(config_data, f)
-    f.close()
 
 def get_last_track():
     with open(os.path.join(config_data["output_directory"], "tracks.csv"), "r") as f:
@@ -29,16 +27,11 @@ def get_last_track():
         return line
 
 def remove_last_track():
-    # https://stackoverflow.com/a/10289740
     with open(os.path.join(config_data["output_directory"], "tracks.csv"), "r") as f:
-        f.seek(0, os.SEEK_END)
-        pos = f.tell() - 1
-        while pos > 0 and f.read(1) != "\n":
-            pos -= 1
-            f.seek(pos, os.SEEK_SET)
-        if pos > 0:
-            f.seek(pos, os.SEEK_SET)
-            f.truncate()
+        lines = f.readlines()
+    with open(os.path.join(config_data["output_directory"], "tracks.csv"), "w") as f:
+        for line in lines[:-1]:
+            f.writelines(line)
 
 @app.command()
 def track(message: str = None, m: str = None, ticket: str = None, t: str = None, past: bool = False, p: bool = False):

--- a/tracker/test_main.py
+++ b/tracker/test_main.py
@@ -39,8 +39,6 @@ class TestMain(unittest.TestCase):
         # Assert
         mock_add_track.assert_has_calls([call('09/04/2013', '08:30', '09:05', 'GWT-001', 'Running this test')])
 
-
-
     @patch("builtins.open")
     @patch("yaml.safe_dump")
     @patch("main.config_data", {"output_directory": "C:\\previous\\output\\directory"})
@@ -68,4 +66,12 @@ class TestMain(unittest.TestCase):
 
         # Assert
         mock_remove.assert_called_once_with("C:\\test\\output\\directory\\tracks.csv")
+
+    @patch("main.remove_last_track")
+    def test_pop_removes_last_track(self, mock_remove_last_track):
+        # Act
+        pop()
+
+        # Assert
+        mock_remove_last_track.assert_called()
     


### PR DESCRIPTION
Remove last track functionality.

## Summary by Sourcery

Enable removal of the most recent tracking entry via a new pop command and clean up unnecessary file close calls

New Features:
- Add remove_last_track function to drop the last entry from the tracks file
- Introduce pop CLI command to remove the last track

Enhancements:
- Remove redundant f.close() calls in file-handling functions

Tests:
- Add unit test for pop command to ensure it invokes remove_last_track